### PR TITLE
feat: ポップアップにバージョン情報を表示する機能を追加

### DIFF
--- a/lighttag-pr/popup.html
+++ b/lighttag-pr/popup.html
@@ -28,6 +28,12 @@
       margin-top: 0;
       margin-bottom: 10px;
     }
+    .version {
+      font-size: 12px;
+      color: #6b7280;
+      text-align: center;
+      margin-top: 10px;
+    }
   </style>
 </head>
 <body>
@@ -36,6 +42,7 @@
     <button id="openOptions">設定を開く</button>
     <button id="goToGitHub">GitHubを開く</button>
   </div>
+  <div class="version" id="version">バージョン: 読み込み中...</div>
   <script src="js/popup.js"></script>
 </body>
 </html>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,6 +1,13 @@
 // GitHub Comment Helper ポップアップスクリプト
 
 document.addEventListener("DOMContentLoaded", (): void => {
+  // バージョン情報を表示
+  const versionElement = document.getElementById("version");
+  if (versionElement) {
+    const manifest = chrome.runtime.getManifest();
+    versionElement.textContent = `バージョン: ${manifest.version}`;
+  }
+
   // オプション画面を開くボタン
   const optionsButton = document.getElementById("openOptions");
   optionsButton?.addEventListener("click", (): void => {


### PR DESCRIPTION
このプルリクエストでは、ポップアップUIに拡張機能のバージョン情報を表示する新機能を追加し、関連するスクリプトを更新してマニフェストファイルからバージョン情報を動的に読み込むように変更しました。

### UIの改良点：

* [`lighttag-pr/popup.html`](diffhunk://#diff-d4c602a7f8b928c434fa564154132182965fa13530511aa8dd281a108687f006R31-R36): 拡張機能のバージョンを表示するための新しい`div`要素を追加しました。この要素にはクラス`version`を付与し、フォントサイズを小さく設定するとともに、テキストを中央揃えで表示するようにスタイルを変更しました。[[1]](diffhunk://#diff-d4c602a7f8b928c434fa564154132182965fa13530511aa8dd281a108687f006R31-R36) [[2]](diffhunk://#diff-d4c602a7f8b928c434fa564154132182965fa13530511aa8dd281a108687f006R45)

### スクリプトの更新内容：

* [`src/popup.ts`](diffhunk://#diff-474e648025143539d50a25990e184704979011829c74eabd70592fa7a7bae6a6R4-R10): 拡張機能のマニフェストファイルからバージョン情報を取得し、ポップアップ内の`version`要素を動的に更新するロジックを実装しました。