### PR TITLE
コメント編集時に、エディタを閉じてもボタンが残ってしまう問題を解消

### DIFF
--- a/src/content.tsx
+++ b/src/content.tsx
@@ -14,39 +14,31 @@ const isPullRequestFilesTab = (): boolean => {
 
 // コメント入力欄にReactコンポーネントをマウントする関数
 const mountCommentHelpers = (
-  commentForm: NodeListOf<HTMLFormElement>,
+  form: HTMLElement,
   labelsConfig: LabelsConfig
 ): void => {
-  for (const form of commentForm) {
-    // すでにマウントされている場合はスキップ
-    if (form.dataset.labelHelperInitialized) continue;
+  // フォーム内のテキストエリアを取得
+  const commentField =
+    form.querySelector<HTMLTextAreaElement>(".js-comment-field");
 
-    // フォーム内のテキストエリアを取得
-    const commentField =
-      form.querySelector<HTMLTextAreaElement>(".js-comment-field");
+  // テキストエリアが見つからない場合はスキップ
+  if (!commentField) return;
 
-    // テキストエリアが見つからない場合はスキップ
-    if (!commentField) continue;
+  // 初期化済みマークを付ける
+  form.dataset.labelHelperInitialized = "true";
 
-    // 初期化済みマークを付ける
-    form.dataset.labelHelperInitialized = "true";
+  // コンテナを作成
+  const helperContainer = document.createElement("div");
+  helperContainer.className = "gh-comment-helper-container";
 
-    // コンテナを作成
-    const helperContainer = document.createElement("div");
-    helperContainer.className = "gh-comment-helper-container";
+  // コメント入力欄の前に挿入
+  form.parentElement?.insertBefore(helperContainer, form);
 
-    // コメント入力欄の前に挿入
-    form.parentElement?.insertBefore(helperContainer, form);
-
-    // Reactルートを作成してマウント
-    const root = createRoot(helperContainer);
-    root.render(
-      <CommentHelperApp
-        commentField={commentField}
-        labelsConfig={labelsConfig}
-      />
-    );
-  }
+  // Reactルートを作成してマウント
+  const root = createRoot(helperContainer);
+  root.render(
+    <CommentHelperApp commentField={commentField} labelsConfig={labelsConfig} />
+  );
 };
 
 // Reactコンポーネントをコメント入力欄にマウント
@@ -57,14 +49,54 @@ const mountReactComponents = (labelsConfig: LabelsConfig): void => {
   }
 
   // GitHub PR画面の新規コメント入力欄を取得 ※編集モードのコメント入力欄は除外
-  const commentForm = document.querySelectorAll<HTMLFormElement>(
+  const commentForm = document.querySelectorAll<HTMLElement>(
     "tab-container.js-previewable-comment-form"
   );
 
-  if (commentForm.length === 0) return;
+  if (commentForm.length !== 0) {
+    for (const form of commentForm) {
+      if (form.dataset.labelHelperInitialized) continue;
 
-  // 各入力欄にReactコンポーネントを追加
-  mountCommentHelpers(commentForm, labelsConfig);
+      // 各入力欄にReactコンポーネントを追加
+      mountCommentHelpers(form, labelsConfig);
+    }
+  }
+
+  // 編集モードのコメント入力欄を取得
+  const editCommentParent =
+    document.querySelectorAll<HTMLFormElement>(".js-comment");
+
+  for (const parent of editCommentParent) {
+    // parent に .is-comment-editing がある場合は表示されるので処理を行う
+    if (parent.classList.contains("is-comment-editing")) {
+      // 編集モードのコメント入力欄を取得
+      const editCommentField = parent.querySelector<HTMLElement>(
+        "div.js-previewable-comment-form"
+      );
+
+      if (editCommentField) {
+        if (editCommentField.dataset.labelHelperInitialized) continue;
+        mountCommentHelpers(editCommentField, labelsConfig);
+      }
+    } else {
+      // 編集モードが非表示なのでラベルボタンを削除する
+      const ghHelperContainer = parent.querySelector(
+        ".gh-comment-helper-container"
+      );
+      if (ghHelperContainer) {
+        ghHelperContainer.remove();
+      }
+
+      // 編集モードのコメント入力欄を取得
+      const editCommentField = parent.querySelector<HTMLElement>(
+        "div.js-previewable-comment-form"
+      );
+
+      if (editCommentField) {
+        delete editCommentField.dataset.labelHelperInitialized;
+      }
+    }
+  }
 };
 
 // 拡張機能の初期化

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -31,9 +31,9 @@ function mountReactComponents(labelsConfig: LabelsConfig): void {
     return;
   }
 
-  // GitHub PR画面のテキストエリアのコンテナを特定
+  // GitHub PR画面の新規コメント入力欄を取得 ※編集モードのコメント入力欄は除外
   const commentForm = document.querySelectorAll<HTMLFormElement>(
-    ".js-previewable-comment-form",
+    "tab-container.js-previewable-comment-form"
   );
 
   if (commentForm.length === 0) return;
@@ -66,7 +66,7 @@ function mountReactComponents(labelsConfig: LabelsConfig): void {
       <CommentHelperApp
         commentField={commentField}
         labelsConfig={labelsConfig}
-      />,
+      />
     );
   }
 }

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -7,38 +7,16 @@ import { CommentHelperApp } from "@/components/domain/content/CommentHelperApp";
 import type { LabelsConfig } from "@/types";
 
 // 現在のURLがGitHubのPRのfilesタブかどうかをチェック
-function isPullRequestFilesTab(): boolean {
+const isPullRequestFilesTab = (): boolean => {
   const url = window.location.href;
   return /https:\/\/github\.com\/.*\/pull\/\d+\/files/.test(url);
-}
+};
 
-// 拡張機能の初期化
-async function initializeExtension(): Promise<void> {
-  // ラベル設定を読み込み
-  const labelsConfig = await loadLabelsConfig();
-
-  // DOM変更の監視を開始
-  createObserver(() => mountReactComponents(labelsConfig));
-
-  // 初期表示されている要素にReactコンポーネントをマウント
-  mountReactComponents(labelsConfig);
-}
-
-// Reactコンポーネントをコメント入力欄にマウント
-function mountReactComponents(labelsConfig: LabelsConfig): void {
-  // 現在のURLがPRのfilesタブでない場合は何もしない
-  if (!isPullRequestFilesTab()) {
-    return;
-  }
-
-  // GitHub PR画面の新規コメント入力欄を取得 ※編集モードのコメント入力欄は除外
-  const commentForm = document.querySelectorAll<HTMLFormElement>(
-    "tab-container.js-previewable-comment-form"
-  );
-
-  if (commentForm.length === 0) return;
-
-  // 各入力欄にReactコンポーネントを追加
+// コメント入力欄にReactコンポーネントをマウントする関数
+const mountCommentHelpers = (
+  commentForm: NodeListOf<HTMLFormElement>,
+  labelsConfig: LabelsConfig
+): void => {
   for (const form of commentForm) {
     // すでにマウントされている場合はスキップ
     if (form.dataset.labelHelperInitialized) continue;
@@ -69,7 +47,37 @@ function mountReactComponents(labelsConfig: LabelsConfig): void {
       />
     );
   }
-}
+};
+
+// Reactコンポーネントをコメント入力欄にマウント
+const mountReactComponents = (labelsConfig: LabelsConfig): void => {
+  // 現在のURLがPRのfilesタブでない場合は何もしない
+  if (!isPullRequestFilesTab()) {
+    return;
+  }
+
+  // GitHub PR画面の新規コメント入力欄を取得 ※編集モードのコメント入力欄は除外
+  const commentForm = document.querySelectorAll<HTMLFormElement>(
+    "tab-container.js-previewable-comment-form"
+  );
+
+  if (commentForm.length === 0) return;
+
+  // 各入力欄にReactコンポーネントを追加
+  mountCommentHelpers(commentForm, labelsConfig);
+};
+
+// 拡張機能の初期化
+const main = async (): Promise<void> => {
+  // ラベル設定を読み込み
+  const labelsConfig = await loadLabelsConfig();
+
+  // DOM変更の監視を開始
+  createObserver(() => mountReactComponents(labelsConfig));
+
+  // 初期表示されている要素にReactコンポーネントをマウント
+  mountReactComponents(labelsConfig);
+};
 
 // 拡張機能を起動
-initializeExtension();
+main();

--- a/src/utils/content/dom-observer.ts
+++ b/src/utils/content/dom-observer.ts
@@ -4,7 +4,17 @@
 export function createObserver(callback: () => void): MutationObserver {
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
+      // ノードの追加を監視
       if (mutation.addedNodes.length) {
+        callback();
+        break;
+      }
+
+      // クラス変更を監視
+      if (
+        mutation.type === "attributes" &&
+        mutation.attributeName === "class"
+      ) {
         callback();
         break;
       }
@@ -15,6 +25,8 @@ export function createObserver(callback: () => void): MutationObserver {
   observer.observe(document.body, {
     childList: true,
     subtree: true,
+    attributes: true,
+    attributeFilter: ["class"],
   });
 
   return observer;


### PR DESCRIPTION
本プルリクエストでは、GitHubのコメントフィールドにReactコンポーネントをマウントする機能のリファクタリングと機能拡張を行いました。主な変更点は以下の通りです：

* 関数の構造を見直し、可読性とメンテナンス性を向上させました
* DOMオブザーバーにおいてクラス属性の変更を監視する機能を追加しました
* 各種タイプのコメントフィールドに対応するロジックを改良しました

### リファクタリングとコード構造の改善：

* [`src/content.tsx`](diffhunk://#diff-507a055293c3db9e85169068a1fac946f647f3cab85ab0ea10d497866a791a36L10-R25)：`isPullRequestFilesTab`関数と`initializeExtension`関数を`const`宣言にリファクタリングし、可読性とコードの一貫性を向上させました。また、個々のコメントフィールドへのReactコンポーネントマウント処理をカプセル化するため、`mountCommentHelpers`を導入しました。
* [`src/content.tsx`](diffhunk://#diff-507a055293c3db9e85169068a1fac946f647f3cab85ab0ea10d497866a791a36L66-R115)：`mountReactComponents`関数を再構築し、新規コメントフィールドと編集中のコメントフィールドを別々に処理するように変更しました。これにより、Reactコンポーネントの適切な初期化とクリーンアップが保証されます。

### 強化されたDOM監視機能：

* [`src/utils/content/dom-observer.ts`](diffhunk://#diff-13ac407b7128fcdeb8101f383c5f55c091f6e0e2e9d5fdfa076d3649e6960a62R7-R29)：DOMオブザーバーにおいて、要素が動的に変更された際にコールバックをトリガーできるよう、クラス属性の変更監視機能を追加しました。